### PR TITLE
feat: store search state in url

### DIFF
--- a/components/gatherer/SearchBar.tsx
+++ b/components/gatherer/SearchBar.tsx
@@ -5,12 +5,21 @@ import { ColorFilter } from 'components/gatherer/ColorFilter'
 import { RuleTextFilter } from 'components/gatherer/RuleTextFilter'
 import { SearchButton } from 'components/gatherer/SearchButton'
 import { PageHeader } from 'components/layout'
-import { FC } from 'react'
+import { useSearchResults } from 'contexts'
+import { FC, KeyboardEvent } from 'react'
 import styled from 'styled-components'
 
 export const SearchBar: FC = () => {
+  const { search, loading } = useSearchResults()
+
+  function handleSubmit(e: KeyboardEvent) {
+    if (loading === false && e.key === 'Enter') {
+      search()
+    }
+  }
+
   return (
-    <PageHeader>
+    <PageHeader onKeyUp={handleSubmit}>
       <SearchRows>
         <SearchRow>
           <CardNameFilter />

--- a/contexts/FiltersContext.tsx
+++ b/contexts/FiltersContext.tsx
@@ -58,6 +58,11 @@ interface UpdateCMCAction {
   payload: Partial<CMCPayload>
 }
 
+interface RehydrateFiltersAction {
+  type: 'rehydrateFilters'
+  payload: FiltersState
+}
+
 type FiltersAction =
   | UpdateNameAction
   | UpdateTypeAction
@@ -65,8 +70,9 @@ type FiltersAction =
   | UpdateColorModeAction
   | UpdateRuleTextAction
   | UpdateCMCAction
+  | RehydrateFiltersAction
 
-const initialState: FiltersState = {
+export const initialFiltersState: FiltersState = {
   cardName: '',
   cardType: '',
   ruleText: '',
@@ -109,6 +115,11 @@ const filtersReducer = (state: FiltersState, action: FiltersAction) => {
         ...state,
         ...action.payload,
       }
+    case 'rehydrateFilters':
+      return {
+        ...state,
+        ...action.payload,
+      }
     default:
       throw new Error()
   }
@@ -121,7 +132,7 @@ export interface FiltersContextType extends FiltersState {
 const FiltersContext = createContext<FiltersContextType | undefined>(undefined)
 
 export const FiltersContextProvider: FC = ({ children }) => {
-  const [state, dispatch] = useReducer(filtersReducer, initialState)
+  const [state, dispatch] = useReducer(filtersReducer, initialFiltersState)
 
   return (
     <FiltersContext.Provider

--- a/utils/gatherer.ts
+++ b/utils/gatherer.ts
@@ -1,0 +1,175 @@
+import {
+  FiltersContextType,
+  FiltersState,
+  initialFiltersState,
+} from 'contexts/FiltersContext'
+import { CMCMode, ColorMode } from 'types'
+
+export function extractFilters({
+  cardName,
+  cardType,
+  ruleText,
+  colors,
+  colorMode,
+  cmc,
+  cmcAlt,
+  cmcMode,
+}: FiltersContextType): FiltersState {
+  return {
+    cardName,
+    cardType,
+    ruleText,
+    colors,
+    colorMode,
+    cmc,
+    cmcAlt,
+    cmcMode,
+  }
+}
+
+const allColors = ['w', 'u', 'b', 'r', 'g']
+
+export function getScryfallQuery({
+  cardName,
+  ruleText,
+  cmc,
+  cmcAlt,
+  cmcMode,
+  cardType,
+  colors,
+  colorMode,
+}: FiltersState): string {
+  const query = ['-is:funny']
+
+  cardName && cardName.length && query.push(`name:${cardName}`)
+
+  if (cardType && cardType.length && cardType.includes(' ')) {
+    const cardTypes = cardType.split(' ')
+    cardTypes.forEach((type) => query.push(`type:${type}`))
+  } else if (cardType.length) {
+    query.push(`type:${cardType}`)
+  }
+
+  if (
+    ruleText &&
+    ruleText.length &&
+    ruleText.startsWith('"') &&
+    ruleText.endsWith('"')
+  ) {
+    query.push(`oracle:${ruleText}`)
+  } else if (ruleText && ruleText.length && ruleText.includes(' ')) {
+    const ruleTextWords = ruleText.split(' ')
+    ruleTextWords.forEach((word) => query.push(`o:${word}`))
+  } else if (ruleText && ruleText.length) {
+    query.push(`o:${ruleText}`)
+  }
+
+  switch (cmcMode) {
+    case 'exactly':
+      query.push(`cmc:${cmc}`)
+      break
+    case 'atLeast':
+      query.push(`cmc>=${cmc}`)
+      break
+    case 'atMost':
+      query.push(`cmc<=${cmc}`)
+      break
+    case 'between':
+      query.push(`cmc>=${cmc} cmc<=${cmcAlt}`)
+      break
+  }
+
+  if (colors.length) {
+    const colorsExcluded = allColors.filter((c) => !colors.includes(c))
+
+    switch (colorMode) {
+      case 'exactly':
+        query.push(`c:${colors.join('')}`)
+        colorsExcluded.forEach((color) => query.push(`-c:${color}`))
+        break
+      case 'exclude':
+        colors.forEach((color) => query.push(`-c:${color}`))
+        break
+      case 'include':
+        query.push(`c:${colors.join('')}`)
+        break
+    }
+  }
+
+  return query.join(' ')
+}
+
+export function getQueryString({
+  cardName,
+  ruleText,
+  cmc,
+  cmcAlt,
+  cmcMode,
+  cardType,
+  colors,
+  colorMode,
+}: FiltersState): string {
+  const params: string[] = []
+
+  if (cardName) {
+    params.push(`cardName=${encodeURIComponent(cardName)}`)
+  }
+
+  if (cardType) {
+    params.push(`cardType=${encodeURIComponent(cardType)}`)
+  }
+
+  if (ruleText) {
+    params.push(`ruleText=${encodeURIComponent(ruleText)}`)
+  }
+
+  if (colors && colors.length) {
+    params.push(`colors=${encodeURIComponent(colors.join(''))}`)
+  }
+
+  if (colorMode) {
+    params.push(`colorMode=${encodeURIComponent(colorMode)}`)
+  }
+
+  params.push(`cmc=${encodeURIComponent(cmc)}`)
+  params.push(`cmcMode=${encodeURIComponent(cmcMode)}`)
+  cmcMode === 'between' && params.push(`cmcAlt=${encodeURIComponent(cmcAlt)}`)
+
+  return params.join('&')
+}
+
+export function parseQueryString(qs: string) {
+  if (!qs) {
+    return null
+  }
+
+  const filters = initialFiltersState
+  const querystring = qs.slice(1)
+  const params = querystring.split('&')
+
+  params.forEach((p) => {
+    const [k, v] = p.split('=')
+
+    if (k === 'cardName' || k === 'ruleText' || k === 'cardType') {
+      filters[k] = decodeURIComponent(v)
+    }
+
+    if (k === 'cmcMode') {
+      filters[k] = decodeURIComponent(v) as CMCMode
+    }
+
+    if (k === 'cmc' || k === 'cmcAlt') {
+      filters[k] = parseInt(decodeURIComponent(v))
+    }
+
+    if (k === 'colorMode') {
+      filters[k] = decodeURIComponent(v) as ColorMode
+    }
+
+    if (k === 'colors') {
+      filters[k] = decodeURIComponent(v).split('')
+    }
+  })
+
+  return filters
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './apiCalls'
 export * from './apiHooks'
+export * from './gatherer'
 export * from './hooks'
 export * from './misc'
 export { sanitizeHandleInput } from './user_handles'


### PR DESCRIPTION
Closes #4 

- Whenever a search is executed update query params using filters state
- When `/gatherer` is first loaded rehydrate filters state from query params then execute a search
- Enable users to fire a search by pressing enter from any focusable element within the search widget