### PR TITLE
refactor: improve card sorting & slicing

### DIFF
--- a/components/cards/Card.tsx
+++ b/components/cards/Card.tsx
@@ -17,6 +17,7 @@ interface Props extends StandardProps {
   card: ScryfallCard
   menuItems?: CardMenuItem[]
   selected?: boolean
+  count?: number
 }
 
 export const Card: FC<Props> = ({
@@ -27,6 +28,7 @@ export const Card: FC<Props> = ({
   selected = false,
   style,
   className,
+  count = 1,
 }) => {
   const { image_uris, card_faces } = card
   let image = highRes ? image_uris?.large : image_uris?.small
@@ -47,6 +49,7 @@ export const Card: FC<Props> = ({
       style={{ ...style, backgroundImage: `url(${url})` }}
       className={containerClass}
     >
+      {count > 1 && <Count>{count}</Count>}
       <Border />
       {menuItems && (
         <Menu>
@@ -79,6 +82,27 @@ const Border = styled.div`
   }
 `
 
+const Count = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: ${colors.n2};
+  display: block;
+  padding: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #fff;
+  border-radius: inherit;
+  border-top-left-radius: 0;
+  border-bottom-right-radius: 0;
+  transition: background-color 0.25s ease;
+
+  .selected &,
+  .selected:hover & {
+    background-color: ${colors.p2};
+  }
+`
+
 const Menu = styled.div`
   position: absolute;
   top: 24%;
@@ -105,6 +129,10 @@ const Container = styled.div`
 
   &:hover ${Border} {
     border-color: ${colors.p1};
+  }
+
+  &:hover ${Count} {
+    background-color: ${colors.p1};
   }
 
   &:hover ${Menu}, &.selected ${Menu} {

--- a/components/cards/Card.tsx
+++ b/components/cards/Card.tsx
@@ -126,6 +126,8 @@ const Container = styled.div`
   background-color: #000;
   transition: box-shadow 0.25s ease;
   box-shadow: 0 0 5px 2px ${colors.n0};
+  user-select: none;
+  transform: translate3d(0, 0, 0);
 
   &:hover ${Border} {
     border-color: ${colors.p1};

--- a/components/deck/Layout.tsx
+++ b/components/deck/Layout.tsx
@@ -24,8 +24,8 @@ export const Layout: FC<Props> = ({ children, mode, ...props }) => {
           key={heading.text}
           style={{ top: `${heading.pos.y}px`, left: `${heading.pos.x}px` }}
         >
-          <span>{heading.text}</span>
           <Pip>{heading.count}</Pip>
+          <span>{heading.text}</span>
         </Heading>
       ))}
     </Plane>
@@ -33,23 +33,26 @@ export const Layout: FC<Props> = ({ children, mode, ...props }) => {
 }
 
 const Heading = styled.div`
+  user-select: none;
   position: absolute;
   width: ${layoutProportions.cardSize.width}px;
   height: ${layoutProportions.headingHeight}px;
   font-size: 18px;
   line-height: 24px;
   color: ${colors.n6};
+  display: flex;
 `
 
 const Pip = styled.span`
   display: inline-flex;
-  width: 22px;
-  height: 22px;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 7px;
   border-radius: 50%;
   align-items: center;
   justify-content: center;
   background-color: ${colors.n1};
-  margin-left: 10px;
+  margin-right: 10px;
   font-size: 14px;
   font-weight: 600;
   color: ${colors.n4};

--- a/components/deck/Layout.tsx
+++ b/components/deck/Layout.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react'
 import { Card } from 'scryfall-sdk'
 import styled from 'styled-components'
 import { LayoutCard, LayoutMode } from 'types'
-import { layoutCards, layoutProportions, sliceDeck } from 'utils'
+import { layoutCards, layoutProportions, sliceDeckBy } from 'utils'
 
 interface Props {
   cards: Card[]
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export const Layout: FC<Props> = ({ children, mode, ...props }) => {
-  const deckSlice = sliceDeck(mode, props.cards)
+  const deckSlice = sliceDeckBy[mode](props.cards)
   const { board, cards, headings } = layoutCards(deckSlice)
 
   return (

--- a/components/deck/Plane.tsx
+++ b/components/deck/Plane.tsx
@@ -120,6 +120,7 @@ const Container = styled.div`
   flex: 1 0 0;
   position: relative;
   overflow: hidden;
+  transform: translate3d(0, 0, 0);
 
   &:hover {
     cursor: grab;

--- a/components/deck/editor/EditorBody.tsx
+++ b/components/deck/editor/EditorBody.tsx
@@ -20,9 +20,7 @@ export const EditorBody: FC = () => {
   return (
     <Layout cards={cards} mode={mode}>
       {(items) =>
-        items.map((item) => (
-          <EditorCard key={item.card.id} card={item.card} {...item.pos} />
-        ))
+        items.map((item) => <EditorCard key={item.card.id} {...item} />)
       }
     </Layout>
   )

--- a/components/deck/editor/EditorCard.tsx
+++ b/components/deck/editor/EditorCard.tsx
@@ -2,19 +2,16 @@ import { Card as BaseCard } from 'components/cards/Card'
 import { useCards } from 'components/deck/CardsContext'
 import { useInspector } from 'contexts'
 import { FC } from 'react'
-import { Card } from 'scryfall-sdk'
 import styled from 'styled-components'
 import { Search, X } from 'styled-icons/boxicons-regular'
+import { LayoutCard } from 'types'
 import { layoutProportions } from 'utils'
 
-interface Props {
-  card: Card
-  x: number
-  y: number
-  z: number
-}
-
-export const EditorCard: FC<Props> = ({ card, x, y, z }) => {
+export const EditorCard: FC<LayoutCard> = ({
+  card,
+  pos: { x, y, z },
+  count,
+}) => {
   const { inspectedCard, inspectCard } = useInspector()
   const { removeCard } = useCards()
   // const { loading } = useDeckEditor()
@@ -36,6 +33,7 @@ export const EditorCard: FC<Props> = ({ card, x, y, z }) => {
 
   return (
     <StyledCard
+      count={count}
       card={card}
       selected={isSelected}
       menuItems={menuItems}

--- a/components/deck/viewer/ViewerBody.tsx
+++ b/components/deck/viewer/ViewerBody.tsx
@@ -20,9 +20,7 @@ export const ViewerBody: FC = () => {
   return (
     <Layout cards={cards} mode={mode}>
       {(items) =>
-        items.map((item) => (
-          <ViewerCard key={item.card.id} card={item.card} {...item.pos} />
-        ))
+        items.map((item) => <ViewerCard key={item.card.id} {...item} />)
       }
     </Layout>
   )

--- a/components/deck/viewer/ViewerCard.tsx
+++ b/components/deck/viewer/ViewerCard.tsx
@@ -1,19 +1,16 @@
 import { Card as BaseCard } from 'components/cards/Card'
 import { useInspector } from 'contexts'
 import { FC } from 'react'
-import { Card } from 'scryfall-sdk'
 import styled from 'styled-components'
 import { Search } from 'styled-icons/boxicons-regular'
+import { LayoutCard } from 'types'
 import { layoutProportions } from 'utils'
 
-interface Props {
-  card: Card
-  x: number
-  y: number
-  z: number
-}
-
-export const ViewerCard: FC<Props> = ({ card, x, y, z }) => {
+export const ViewerCard: FC<LayoutCard> = ({
+  card,
+  pos: { x, y, z },
+  count,
+}) => {
   const { inspectedCard, inspectCard } = useInspector()
 
   const isSelected = !!inspectedCard && inspectedCard.id === card.id
@@ -28,6 +25,7 @@ export const ViewerCard: FC<Props> = ({ card, x, y, z }) => {
 
   return (
     <StyledCard
+      count={count}
       card={card}
       selected={isSelected}
       menuItems={menuItems}

--- a/types/editor.ts
+++ b/types/editor.ts
@@ -19,6 +19,7 @@ export interface LayoutHeading {
 
 export interface LayoutCard {
   card: Card
+  count: number
   pos: LayoutPos
 }
 

--- a/utils/editor.ts
+++ b/utils/editor.ts
@@ -97,7 +97,7 @@ export const layoutProportions = {
   },
   columnGap: 24,
   cardGap: 34,
-  headingHeight: 60,
+  headingHeight: 68,
   gutter: 30,
 }
 

--- a/utils/editor.ts
+++ b/utils/editor.ts
@@ -40,14 +40,20 @@ export function getCardColor(colors: Color[]): string {
 
 export function sliceDeckByCMC(cards: Card[]): DeckSlice {
   const deckByCMC: DeckSlice = {}
+
+  const largestCMC = cards.reduce((prev, current) => {
+    return current.cmc > prev ? current.cmc : prev
+  }, 0)
+
+  for (let i = 0; i <= largestCMC; i++) {
+    deckByCMC[i] = []
+  }
+
   cards.forEach((card) => {
     const cmc = card.cmc
-
-    if (typeof deckByCMC[cmc] === 'undefined') {
-      deckByCMC[cmc] = []
+    if (typeof deckByCMC[cmc] === 'object') {
+      deckByCMC[cmc].push(card)
     }
-
-    deckByCMC[cmc].push(card)
   })
 
   return deckByCMC
@@ -55,31 +61,42 @@ export function sliceDeckByCMC(cards: Card[]): DeckSlice {
 
 export function sliceDeckByType(cards: Card[]): DeckSlice {
   const deckByType: DeckSlice = {}
+  const draftDeckByType: DeckSlice = {}
   cards.forEach((card) => {
     const type = getCardType(card.type_line)
 
-    if (typeof deckByType[type] === 'undefined') {
-      deckByType[type] = []
+    if (typeof draftDeckByType[type] === 'undefined') {
+      draftDeckByType[type] = []
     }
 
-    deckByType[type].push(card)
+    draftDeckByType[type].push(card)
   })
+
+  const entries = Object.entries(draftDeckByType).sort(
+    (a, b) => b[1].length - a[1].length,
+  )
+  entries.forEach(([key, val]) => (deckByType[key] = val))
 
   return deckByType
 }
 
 export function sliceDeckByColor(cards: Card[]): DeckSlice {
+  const draftDeckSlice: DeckSlice = {}
   const deckByColor: DeckSlice = {}
   cards.forEach((card) => {
     const color = getCardColor(card.color_identity || [])
 
-    if (typeof deckByColor[color] === 'undefined') {
-      deckByColor[color] = []
+    if (typeof draftDeckSlice[color] === 'undefined') {
+      draftDeckSlice[color] = []
     }
 
-    deckByColor[color].push(card)
+    draftDeckSlice[color].push(card)
   })
 
+  const entries = Object.entries(draftDeckSlice).sort(
+    (a, b) => b[1].length - a[1].length,
+  )
+  entries.forEach(([key, val]) => (deckByColor[key] = val))
   return deckByColor
 }
 

--- a/utils/editor.ts
+++ b/utils/editor.ts
@@ -8,17 +8,10 @@ import {
   LayoutMode,
 } from 'types'
 
-export function sliceDeck(mode: LayoutMode, cards: Card[]) {
-  switch (mode) {
-    case 'type':
-      return sliceDeckByType(cards)
-    case 'color':
-      return sliceDeckByColor(cards)
-    case 'cmc':
-      return sliceDeckByCMC(cards)
-    default:
-      throw new Error(`${mode} is not a valid mode for slicing a deck`)
-  }
+export const sliceDeckBy: Record<LayoutMode, (cards: Card[]) => DeckSlice> = {
+  type: sliceDeckByType,
+  color: sliceDeckByColor,
+  cmc: sliceDeckByCMC,
 }
 
 export function getCardType(cardType: string): string {

--- a/utils/editor.ts
+++ b/utils/editor.ts
@@ -95,7 +95,7 @@ export const layoutProportions = {
     width: 180,
     height: 250,
   },
-  columnGap: 20,
+  columnGap: 24,
   cardGap: 34,
   headingHeight: 60,
   gutter: 30,
@@ -128,13 +128,16 @@ export function layoutCards(deck: DeckSlice): Layout {
       largestColumn = columnCards.length
     }
 
-    columnCards.forEach((card, cardIndex) => {
+    const uniques = countUniques(columnCards)
+
+    uniques.forEach((card, cardIndex) => {
       const y =
         layoutProportions.headingHeight + cardIndex * layoutProportions.cardGap
       const z = cardIndex + 1
 
       cards.push({
         card,
+        count: card.count,
         pos: {
           x: x + layoutProportions.gutter,
           y: y + layoutProportions.gutter,
@@ -189,4 +192,45 @@ export function parseBulkAddInput(input: string) {
   })
 
   return cards
+}
+
+/** Sort Function */
+function byCardName(a: Card, b: Card) {
+  if (a.name.toLowerCase() > b.name.toLowerCase()) {
+    return 1
+  }
+  if (a.name.toLowerCase() < b.name.toLowerCase()) {
+    return -1
+  }
+
+  return 0
+}
+
+type CardStack = Record<string, Card[]>
+
+interface CardWithCount extends Card {
+  count: number
+}
+
+function countUniques(cards: Card[]): CardWithCount[] {
+  const stacks: CardStack = {}
+
+  cards.forEach((card) => {
+    if (typeof stacks[card.name] !== 'object') {
+      stacks[card.name] = []
+    }
+
+    stacks[card.name].push(card)
+  })
+
+  const uniques = Object.entries(stacks)
+
+  const countedCards = uniques.map(([_, stack]) => {
+    const count = stack.length
+    const card = stack[0]
+
+    return { ...card, count }
+  })
+
+  return countedCards.sort(byCardName)
 }


### PR DESCRIPTION
- Consolidate duplicated cards into a single card with a count in the top right corner
- Sort `color` and `type` stacks by size, largest to smallest